### PR TITLE
[sparse csv] allow empty fields in CSV `dense' rows

### DIFF
--- a/csv/csv_parser.mly
+++ b/csv/csv_parser.mly
@@ -42,9 +42,13 @@ value:
 | FLOAT { (`Float $1) }
 | STRING { (`String $1) }
 
+value_opt:
+| value { Some $1}
+| { None }
+
 values:
-| value COMMA values { $1 :: $3 }
-| value { [ $1 ] }
+| value_opt COMMA values { $1 :: $3 }
+| value_opt { [ $1 ] }
 
 row:
 | row_sans_nl EOL { $1 }
@@ -55,11 +59,11 @@ row:
 | EOF { `EOF }
 
 row_sans_nl:
-| dense_row { `Dense $1 }
+| dense_row { $1 }
 | sparse_row { `Sparse $1 }
 
 dense_row:
-| values { $1 }
+| values { Csv_types.parse_opt_row $1 }
 
 sparse_row:
 | LCURLY pairs RCURLY { $2 }

--- a/csv/csv_types.ml
+++ b/csv/csv_types.ml
@@ -2,3 +2,24 @@ type value = [ `Int of int | `Float of float | `String of string ]
 type dense = value list
 type sparse = (int * value) list
 type row = [ `Dense of dense | `Sparse of sparse | `EOF ]
+type opt_row = value option list
+
+let parse_opt_row_sparse opt_row =
+  let rec loop i accu opt_row =
+    match opt_row with
+    | None :: tl -> loop (succ i) accu tl
+    | (Some v) :: tl -> loop (succ i) ((i,v) :: accu) tl
+    | [] -> accu
+  in
+  loop 0 [] opt_row
+
+exception Sparse
+let unopt = function
+  | Some x -> x
+  | None -> raise Sparse
+
+let parse_opt_row_dense opt_row = List.map unopt opt_row
+
+let parse_opt_row opt_row =
+  try `Dense(parse_opt_row_dense opt_row)
+  with Sparse -> `Sparse(parse_opt_row_sparse opt_row)


### PR DESCRIPTION
Interpret missing CSV fields as the anonymous categorical value