### PR TITLE
[Learn][-g, --max-leaf-gamma] limit the maximum gamma in a leaf

### DIFF
--- a/feat_utils.ml
+++ b/feat_utils.ml
@@ -1,5 +1,17 @@
 open Dog_t
 
+let apply_max_gamma ~max_gamma gamma =
+  if gamma < 0.0 then
+    max gamma (~-. max_gamma)
+  else
+    min gamma max_gamma
+
+let apply_max_gamma_opt ~max_gamma_opt left right =
+  match max_gamma_opt with
+    | None -> left, right
+    | Some max_gamma ->
+      apply_max_gamma ~max_gamma left, apply_max_gamma ~max_gamma right
+
 let array_of_afeature = function
   | `Cat cat -> (
       let categories = Array.of_list cat.c_categories in

--- a/feat_utils.mli
+++ b/feat_utils.mli
@@ -1,3 +1,4 @@
+val apply_max_gamma_opt : max_gamma_opt:float option -> float -> float -> float * float
 val array_of_afeature : Feat.afeature ->
   [ `Float of (int * float) array
   | `Int of (int * int) array

--- a/logistic.ml
+++ b/logistic.ml
@@ -347,7 +347,7 @@ let updated_loss ~gamma  ~sum_l ~sum_z ~sum_w =
 
 exception EmptyFold
 
-class splitter binarization_threshold_opt y_feature n =
+class splitter max_gamma_opt binarization_threshold_opt y_feature n =
   let y, positive_category, negative_category_opt =
     y_array_of_feature binarization_threshold_opt y_feature n in
 
@@ -590,10 +590,12 @@ class splitter binarization_threshold_opt y_feature n =
                left.sum_w.(k) <> 0.0 &&
                right.sum_w.(k_1) <> 0.0
             then (
-
               let left_gamma  = left.sum_z.(k)    /. left.sum_w.(k)    in
               let right_gamma = right.sum_z.(k_1) /. right.sum_w.(k_1) in
 
+              let left_gamma, right_gamma =
+                Feat_utils.apply_max_gamma_opt ~max_gamma_opt left_gamma right_gamma
+              in
               let loss_left = updated_loss
                   ~gamma:left_gamma
                   ~sum_l:left.sum_l.(k)
@@ -692,6 +694,10 @@ class splitter binarization_threshold_opt y_feature n =
 
               let left_gamma  = left.sum_z.(k)    /. left.sum_w.(k)    in
               let right_gamma = right.sum_z.(k+1) /. right.sum_w.(k+1) in
+
+              let left_gamma, right_gamma =
+                Feat_utils.apply_max_gamma_opt ~max_gamma_opt left_gamma right_gamma
+              in
 
               if match monotonicity with
                  | `Positive -> right_gamma > left_gamma

--- a/logistic.mli
+++ b/logistic.mli
@@ -5,4 +5,6 @@ type binarization_threshold = [
 ]
 
 val probability : float -> float
-class splitter : binarization_threshold option -> Feat.afeature -> int -> Loss.splitter
+class splitter :
+  float option -> binarization_threshold option -> Feat.afeature -> int
+    -> Loss.splitter

--- a/sgbt.ml
+++ b/sgbt.ml
@@ -22,6 +22,7 @@ type conf = {
   excluded_feature_name_regexp_opt : Pcre.regexp option;
   fold_feature_opt : Feat_utils.feature_descr option;
   max_trees_opt : int option;
+  max_gamma_opt : float option;
   binarization_threshold_opt : Logistic.binarization_threshold option;
   feature_monotonicity : feature_monotonicity;
 }
@@ -100,7 +101,7 @@ let rec learn_with_fold_rate conf t iteration =
     Tree.max_depth = conf.max_depth;
     feature_map = t.feature_map;
     feature_monotonicity_map;
-    splitter = t.splitter
+    splitter = t.splitter;
   } in
 
   (* draw a random subset of this fold *)
@@ -402,9 +403,10 @@ let learn conf =
     match conf.loss_type with
       | `Logistic ->
         new Logistic.splitter
-          conf.binarization_threshold_opt y_feature num_observations
+          conf.max_gamma_opt conf.binarization_threshold_opt
+          y_feature num_observations
       | `Square ->
-        new Square.splitter y_feature num_observations
+        new Square.splitter conf.max_gamma_opt y_feature num_observations
   in
 
   let eval = Tree.mk_eval num_observations in

--- a/sgbt.mli
+++ b/sgbt.mli
@@ -15,6 +15,7 @@ type conf = {
   excluded_feature_name_regexp_opt : Pcre.regexp option;
   fold_feature_opt : Feat_utils.feature_descr option;
   max_trees_opt : int option;
+  max_gamma_opt : float option;
   binarization_threshold_opt : Logistic.binarization_threshold option;
   feature_monotonicity : feature_monotonicity;
 }

--- a/square.ml
+++ b/square.ml
@@ -105,7 +105,7 @@ let updated_loss ~gamma  ~sum_l ~sum_z ~sum_n =
 
 exception EmptyFold
 
-class splitter y_feature n =
+class splitter max_gamma_opt y_feature n =
   let y = get_y_as_array y_feature n in
 
   let z = Array.make n 0.0 in
@@ -333,6 +333,10 @@ class splitter y_feature n =
               let left_gamma  = left.sum_z.(k)    /. (float left_n)  in
               let right_gamma = right.sum_z.(k_1) /. (float right_n) in
 
+              let left_gamma, right_gamma =
+                Feat_utils.apply_max_gamma_opt ~max_gamma_opt left_gamma right_gamma
+              in
+
               if match monotonicity with
                  | `Positive -> right_gamma > left_gamma
                  | `Negative -> right_gamma < left_gamma
@@ -429,6 +433,10 @@ class splitter y_feature n =
 
               let left_gamma  = left.sum_z.(k)    /. (float left_n)  in
               let right_gamma = right.sum_z.(k+1) /. (float right_n) in
+
+              let left_gamma, right_gamma =
+                Feat_utils.apply_max_gamma_opt ~max_gamma_opt left_gamma right_gamma
+              in
 
               let loss_left = updated_loss
                   ~gamma:left_gamma

--- a/square.mli
+++ b/square.mli
@@ -1,1 +1,1 @@
-class splitter : Feat.afeature -> int -> Loss.splitter
+class splitter : float option -> Feat.afeature -> int -> Loss.splitter

--- a/tree.ml
+++ b/tree.ml
@@ -77,7 +77,7 @@ type m = {
   max_depth : int;
   feature_map : Feat_map.t;
   feature_monotonicity_map : feature_monotonicity_map;
-  splitter : Loss.splitter
+  splitter : Loss.splitter;
 }
 
 let string_of_split { s_gamma ; s_n ; s_loss } =


### PR DESCRIPTION
This option greatly enhances the stability of the learning process, primarily in the context of logistic models, which are prone to diverging where there are regions of the feature space where the probability value approaches either 0 or 1, and where correspondingly the gradient diverges. This works by constraining the gamma values produced by the splitter into a reasonable range. While this might reduce the speed of convergence in some cases, an appropriate choice of max gamma generally enhances model stability.